### PR TITLE
Fixing Muddy and Workshop 

### DIFF
--- a/maps/muddy_easy.ahk
+++ b/maps/muddy_easy.ahk
@@ -62,29 +62,25 @@ muddyGameScript(timeScale) {
 			
 			Send("{sc035}")	;dart right 002
 			Sleep(timeScale * 3100)
-			
+	
 			Send("{vk5A}")	;sniper
 			Sleep(timeScale * 100)
 			MouseMove(1017,917)
 			Sleep(timeScale * 100)
 			Click("1017,917")
-			Sleep(timeScale * 100)
-			
-			Click("1017,917")	;click sniper
-			Sleep(timeScale * 100)
+			Sleep(timeScale * 100)	
 			
 			Send("^{vk09}")	;change target priority to strong
-			Sleep(timeScale * 6000)
-			
+			Sleep(timeScale * 10000)
+			Click("1017,917")
+			Sleep(timeScale * 500)
 			Send("{vkBC}")	;sniper 100
 			Sleep(timeScale * 7200)
-			
 			Send("{sc035}")	;sniper 101
 			Sleep(timeScale * 4700)
-			
 			Send("{sc035}")	;sniper 102
 			Sleep(timeScale * 100)
-			
+	
 			Click("960,540")	;click center of screen to dismiss menu
 			Sleep(timeScale * 100)
 			

--- a/maps/workshop_easy.ahk
+++ b/maps/workshop_easy.ahk
@@ -19,7 +19,7 @@ workshopGameScript(timeScale) {
 			MouseMove(1240,325)
 			Sleep(timeScale * 100)
 			Click("1240,325")
-			Sleep(timeScale * 10000)
+			Sleep(timeScale * 15000)
 			
 			Send("{vk41}")		; Wizard
 			Sleep(timeScale * 100)
@@ -28,8 +28,8 @@ workshopGameScript(timeScale) {
 			Click("190,639")
 			Sleep(timeScale * 100)
 			
-			Click("190,639")	; Click Wizard for upgrade menu
-			Sleep(timeScale * 5000)
+			Click("190,639")	; Click Wizard for upgrade menu/
+			Sleep(timeScale * 10000)
 			
 			Send("{vkBE}")		; Upgrade Wizard 0-1-0
 			Sleep(timeScale * 21000)


### PR DESCRIPTION
I made my own script, and thought to myself "it would be cool if someone already did this". This repo is awesome and all I did was increase sleep time to fix a selection issue on Workshop. On muddy the sniper was losing on first leads because it had one too many click events which caused its upgrade path to get off, so I removed a click and increased sleep on the initial load in to account for longer computer load times. 